### PR TITLE
surfaceflinger: Fix deep sleep issue

### DIFF
--- a/services/surfaceflinger/SurfaceFlinger_hwc1.cpp
+++ b/services/surfaceflinger/SurfaceFlinger_hwc1.cpp
@@ -96,6 +96,9 @@
 
 #define DISPLAY_COUNT       1
 
+#define FBIOBLANK               0x4611
+#define FB_BLANK_UNBLANK        0
+
 /*
  * DEBUG_SCREENSHOTS: set to true to check that screenshots are not all
  * black pixels.
@@ -2701,6 +2704,16 @@ void SurfaceFlinger::setPowerModeInternal(const sp<DisplayDevice>& hw,
         int mode) {
     ALOGD("Set power mode=%d, type=%d flinger=%p", mode, hw->getDisplayType(),
             this);
+
+    if (mode == 2) //Awaking the lcd
+    {
+	int fd, ret;
+	fd = open("/dev/graphics/fb0",O_WRONLY);
+	ret = ioctl(fd, FBIOBLANK, FB_BLANK_UNBLANK);
+
+	if (ret < 0)
+		ALOGE("Error waking up LCD: %d (%s)\n", ret, strerror(errno));
+    }
     int32_t type = hw->getDisplayType();
     int currentMode = hw->getPowerMode();
 


### PR DESCRIPTION
* The problem is that after unplugging the phone from the USB port, the screen no longer turns on. This is caused because the FB is set to sleep, and no one wakes it up whenever the power button is pressed, thats why we are going to do so manually.